### PR TITLE
change drone yaml file name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Render the YAML file:
 drone jsonnet --stream \
               --format \
               --source <(jsonnet -J vendor/ drone.jsonnet) \
-              --target .drone.yaml
+              --target .drone.yml
 ```
 
 > Originally the intention was to render YAML with `std.manifestYamlStream()`,


### PR DESCRIPTION
drone uses .drone.yml by default