### PR TITLE
Add shorthands for tags

### DIFF
--- a/docs/drone/pipeline/digitalocean/step.md
+++ b/docs/drone/pipeline/digitalocean/step.md
@@ -38,6 +38,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -265,6 +267,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/docs/drone/pipeline/docker/step.md
+++ b/docs/drone/pipeline/docker/step.md
@@ -51,6 +51,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -381,6 +383,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/docs/drone/pipeline/exec/step.md
+++ b/docs/drone/pipeline/exec/step.md
@@ -38,6 +38,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -265,6 +267,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/docs/drone/pipeline/kubernetes/step.md
+++ b/docs/drone/pipeline/kubernetes/step.md
@@ -49,6 +49,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -361,6 +363,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/docs/drone/pipeline/macstadium/step.md
+++ b/docs/drone/pipeline/macstadium/step.md
@@ -38,6 +38,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -265,6 +267,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/docs/drone/pipeline/ssh/step.md
+++ b/docs/drone/pipeline/ssh/step.md
@@ -38,6 +38,8 @@ drone.pipeline.step.<attribute>
   * [`fn onPushToMainBranch()`](#fn-whenonpushtomainbranch)
   * [`fn onPushToMasterBranch()`](#fn-whenonpushtomasterbranch)
   * [`fn onSuccess()`](#fn-whenonsuccess)
+  * [`fn onTag()`](#fn-whenontag)
+  * [`fn onTagPattern()`](#fn-whenontagpattern)
   * [`fn withBranch(value)`](#fn-whenwithbranch)
   * [`fn withBranchMixin(value)`](#fn-whenwithbranchmixin)
   * [`fn withCron(value)`](#fn-whenwithcron)
@@ -265,6 +267,25 @@ onSuccess()
 
 `onSuccess` will conditionally limit this step to a successful
 pipeline
+
+
+#### fn when.onTag
+
+```ts
+onTag()
+```
+
+`onTag` will conditionally limit this step to a `tag` event
+
+
+#### fn when.onTagPattern
+
+```ts
+onTagPattern()
+```
+
+`onTagPattern` will conditionally limit this step to the
+creation of a `tag` matching the pattern `tag_pattern`.
 
 
 #### fn when.withBranch

--- a/main.libsonnet
+++ b/main.libsonnet
@@ -190,6 +190,21 @@ local lib =
                 ),
                 onPullRequest(): self.event.withIncludeMixin(['pull_request']),
 
+                '#onTag':: d.fn(
+                  |||
+                    `onTag` will conditionally limit this step to a `tag` event
+                  |||,
+                ),
+                onTag(): self.event.withIncludeMixin(['tag']),
+
+                '#onTagPattern':: d.fn(
+                  |||
+                    `onTagPattern` will conditionally limit this step to the
+                    creation of a `tag` matching the pattern `tag_pattern`.
+                  |||,
+                ),
+                onTagPattern(tag_pattern): self.ref.withIncludeMixin(['refs/tags/' + tag_pattern]),
+
                 '#onSuccess':: d.fn(
                   |||
                     `onSuccess` will conditionally limit this step to a successful


### PR DESCRIPTION
Add two new shorthands:

* onTag: trigger the step based on the creation of any tag. This one is useful because it's not immediately obvious that the creation of a tag is an event.

* onTagPattern: trigger the step based on the creation of a tag matching a pattern. Including `Pattern` in the name emphasizes that this should be a pattern (e.g. `v*.*.*`) because the use case for triggering on a specific tag is very limited. This one is useful because it's also not obvious that in order to match on specific tags you need to match on a a reference.